### PR TITLE
remove scroll from score table on index page

### DIFF
--- a/PopnScoreTool2/wwwroot/js/index.js
+++ b/PopnScoreTool2/wwwroot/js/index.js
@@ -205,7 +205,6 @@ const updateGrid = (data) => {
         limit: 20,
       },
       fixedHeader: true,
-      height: '400px',
       style: {
         table: {
           width: '100%',


### PR DESCRIPTION
スコアを一覧する際、現在は画像のようにテーブルにもスクロールが表示されており一覧する際には結構不便であると感じています。
![スクリーンショット 2022-10-16 162150](https://user-images.githubusercontent.com/3670931/196024444-c781db27-cb38-4d2f-8290-674e81638eed.png)

テーブルのスクロールはなくして、ページ全体のスクロールにゆだねるとデータの一覧性が高まり利便性が向上すると感じるのですがいかがでしょうか？(Pagenationが遠くなるというデメリットはあります。)
![image](https://user-images.githubusercontent.com/3670931/196024440-1662e5e9-028b-41bc-99b7-709d763c574e.png)
